### PR TITLE
Fixed issue with ansi (single-line comments) and updated Makefile for compiling dynamic and static lib.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,2 +1,60 @@
-all: cJSON.c test.c
-	gcc cJSON.c test.c -o test -lm
+OBJ = cJSON.o
+LIBNAME = libcjson
+TESTS = test
+
+PREFIX ?= /usr/local
+INCLUDE_PATH ?= include/cjson
+LIBRARY_PATH ?= lib
+
+INSTALL_INCLUDE_PATH = $(DESTDIR)$(PREFIX)/$(INCLUDE_PATH)
+INSTALL_LIBRARY_PATH = $(DESTDIR)$(PREFIX)/$(LIBRARY_PATH)
+
+INSTALL ?= cp -a
+
+R_CFLAGS = -fpic $(CFLAGS) -Wall -Werror -Wstrict-prototypes -Wwrite-strings
+
+uname_S := $(shell sh -c 'uname -s 2>/dev/null || echo false')
+
+## shared lib
+DYLIBNAME = $(LIBNAME).so 
+DYLIBCMD = $(CC) -shared -o $(DYLIBNAME)
+
+## create dynamic (shared) library on Darwin (base OS for MacOSX and IOS)
+ifeq (Darwin, $(uname_S))
+  DYLIBNAME = $(LIBNAME).dylib
+endif
+## create dyanmic (shared) library on SunOS
+ifeq (SunOS, $(uname_S))
+  DYLIBCMD = $(CC) -G -o $(DYLIBNAME)
+  INSTALL = cp -r
+endif
+
+## static lib
+STLIBNAME = $(LIBNAME).a
+
+.PHONY: all clean install
+
+all: $(DYLIBNAME) $(STLIBNAME) $(TESTS)
+
+$(DYLIBNAME): $(OBJ)
+		$(DYLIBCMD) $< $(LDFLAGS)
+	
+$(STLIBNAME): $(OBJ)
+		ar rcs $@ $<
+
+$(OBJ): cJSON.c cJSON.h 
+
+.c.o:
+		$(CC) -ansi -pedantic -c $(R_CFLAGS) $<
+
+$(TESTS): cJSON.c cJSON.h test.c
+		$(CC)  cJSON.c test.c -o test -lm -I.
+
+install: $(DYLIBNAME) $(STLIBNAME)
+		mkdir -p $(INSTALL_LIBRARY_PATH) $(INSTALL_INCLUDE_PATH)
+		$(INSTALL) cJSON.h $(INSTALL_INCLUDE_PATH)
+		$(INSTALL) $(DYLIBNAME) $(INSTALL_LIBRARY_PATH)
+		$(INSTALL) $(STLIBNAME) $(INSTALL_LIBRARY_PATH)
+
+clean: 
+		rm -rf $(DYLIBNAME) $(STLIBNAME) $(TESTS) *.o

--- a/cJSON.c
+++ b/cJSON.c
@@ -584,13 +584,13 @@ void cJSON_Minify(char *json)
 	while (*json)
 	{
 		if (*json==' ') json++;
-		else if (*json=='\t') json++;	// Whitespace characters.
+		else if (*json=='\t') json++;	/* Whitespace characters. */
 		else if (*json=='\r') json++;
 		else if (*json=='\n') json++;
-		else if (*json=='/' && json[1]=='/')  while (*json && *json!='\n') json++;	// double-slash comments, to end of line.
-		else if (*json=='/' && json[1]=='*') {while (*json && !(*json=='*' && json[1]=='/')) json++;json+=2;}	// multiline comments.
-		else if (*json=='\"'){*into++=*json++;while (*json && *json!='\"'){if (*json=='\\') *into++=*json++;*into++=*json++;}*into++=*json++;} // string literals, which are \" sensitive.
-		else *into++=*json++;			// All other characters.
+		else if (*json=='/' && json[1]=='/')  while (*json && *json!='\n') json++;	/* double-slash comments, to end of line. */
+		else if (*json=='/' && json[1]=='*') {while (*json && !(*json=='*' && json[1]=='/')) json++;json+=2;}	/* multiline comments. */
+		else if (*json=='\"'){*into++=*json++;while (*json && *json!='\"'){if (*json=='\\') *into++=*json++;*into++=*json++;}*into++=*json++;} /* string literals, which are \" sensitive. */
+		else *into++=*json++;			/* All other characters. */
 	}
-	*into=0;	// and null-terminate.
+	*into=0;	/* and null-terminate. */
 }


### PR DESCRIPTION
As this is not the official repository of the library, I don't know if it's ok to change the source file; but as the library is intended to be ANSI C compliant, I replaced single-line comments (`//`) with multi-line comments (`/* ... */`), because single-line comments are not compliant with ANSI. So when trying to compile with the flags `-ansi -pedantic`, the compilation won't fail.

Also, I modified the `Makefile` so it's possible to use the library as a dynamic (shared) or static library with simple steps.
Inside the repo folder, run : 
`make`
`make test`
`[sudo] make install`
Once everything went without error, you can run `make clean` to remove the object, test and lib files.

To use the dynamic or static lib, compile your code with the `-lcjson` flag. The default  location for the lib and header installation is `/usr/local/lib/cjson` and `/usr/local/include/cjson`, respectively.

Tested on Ubuntu 14.04.1 and Mac OS X Lion 10.7.5.
