### PR TITLE
add new macro for iterating over an array

### DIFF
--- a/cJSON.h
+++ b/cJSON.h
@@ -142,6 +142,9 @@ extern void cJSON_Minify(char *json);
 #define cJSON_SetIntValue(object,val)			((object)?(object)->valueint=(object)->valuedouble=(val):(val))
 #define cJSON_SetNumberValue(object,val)		((object)?(object)->valueint=(object)->valuedouble=(val):(val))
 
+/* Macro for iterating over an array */
+#define cJSON_ArrayForEach(pos, head)			for(pos = (head)->child; pos != NULL; pos = pos->next)
+
 #ifdef __cplusplus
 }
 #endif


### PR DESCRIPTION
Use cJSON_GetArrayItem(item, i) to get every item of a large array is very slow.
It's better to use a macro to iterate over an array.