### PR TITLE
Handle invalid numbers

### DIFF
--- a/cJSON.c
+++ b/cJSON.c
@@ -166,9 +166,10 @@ static char *print_number(cJSON *item,printbuffer *p)
 		else	str=(char*)cJSON_malloc(64);	/* This is a nice tradeoff. */
 		if (str)
 		{
-			if (fabs(floor(d)-d)<=DBL_EPSILON && fabs(d)<1.0e60)sprintf(str,"%.0f",d);
-			else if (fabs(d)<1.0e-6 || fabs(d)>1.0e9)			sprintf(str,"%e",d);
-			else												sprintf(str,"%f",d);
+			if (fpclassify(d) != FP_ZERO && !isnormal(d))				sprintf(str,"null");
+			else if (fabs(floor(d)-d)<=DBL_EPSILON && fabs(d)<1.0e60)	sprintf(str,"%.0f",d);
+			else if (fabs(d)<1.0e-6 || fabs(d)>1.0e9)					sprintf(str,"%e",d);
+			else														sprintf(str,"%f",d);
 		}
 	}
 	return str;

--- a/test.c
+++ b/test.c
@@ -131,6 +131,9 @@ void create_objects()
 	
 	out=cJSON_Print(root);	cJSON_Delete(root);	printf("%s\n",out);	free(out);
 
+	root=cJSON_CreateObject();
+	cJSON_AddNumberToObject(root,"number", 1.0/0.0);
+	out=cJSON_Print(root);	cJSON_Delete(root);	printf("%s\n",out);	free(out);
 }
 
 int main (int argc, const char * argv[]) {


### PR DESCRIPTION
Previously cJSON generated invalid JSON when a number was infinite or
similar. This patch changes the behaviour to match javascript, that is
to render such a number as null.