### PR TITLE
Fix format problem with empty objects

### DIFF
--- a/cJSON.c
+++ b/cJSON.c
@@ -563,7 +563,7 @@ static char *print_object(cJSON *item,int depth,int fmt,printbuffer *p)
 		else	out=(char*)cJSON_malloc(fmt?depth+4:3);
 		if (!out)	return 0;
 		ptr=out;*ptr++='{';
-		if (fmt) {*ptr++='\n';for (i=0;i<depth-1;i++) *ptr++='\t';}
+		if (fmt) {*ptr++='\n';for (i=0;i<depth;i++) *ptr++='\t';}
 		*ptr++='}';*ptr++=0;
 		return out;
 	}


### PR DESCRIPTION
When printing empty objects, the closing curly brace was missing one
indentation level.

Example from the output of test_utils:

BEFORE FIX:
```json
{
	"foo":	"bar",
	"child":	{
		"grandchild":	{
	}
	}
}
```

AFTER FIX:
```json
{
	"foo":	"bar",
	"child":	{
		"grandchild":	{
		}
	}
}
```