### PR TITLE
Fix printing of empty string pointers

### DIFF
--- a/cJSON.c
+++ b/cJSON.c
@@ -253,6 +253,15 @@ static const char *parse_string(cJSON *item,const char *str)
 static char *print_string_ptr(const char *str,printbuffer *p)
 {
 	const char *ptr;char *ptr2,*out;int len=0,flag=0;unsigned char token;
+
+	if (!str)
+	{
+		if (p)	out=ensure(p,3);
+		else	out=(char*)cJSON_malloc(3);
+		if (!out) return 0;
+		strcpy(out,"\"\"");
+		return out;
+	}
 	
 	for (ptr=str;*ptr;ptr++) flag|=((*ptr>0 && *ptr<32)||(*ptr=='\"')||(*ptr=='\\'))?1:0;
 	if (!flag)
@@ -268,14 +277,6 @@ static char *print_string_ptr(const char *str,printbuffer *p)
 		return out;
 	}
 	
-	if (!str)
-	{
-		if (p)	out=ensure(p,3);
-		else	out=(char*)cJSON_malloc(3);
-		if (!out) return 0;
-		strcpy(out,"\"\"");
-		return out;
-	}
 	ptr=str;while ((token=*ptr) && ++len) {if (strchr("\"\\\b\f\n\r\t",token)) len++; else if (token<32) len+=5;ptr++;}
 	
 	if (p)	out=ensure(p,len+3);


### PR DESCRIPTION
Once the check if str is NULL is reached, str has already been
derereferenced in the for loop, so in the case that the if clause would
be entered, the program has already crashed due to a null pointer
dereference.

By checking the content of str before dereferencing, the code in the if
clause is actually useful.

```c
for (ptr=str;*ptr;ptr++) flag|=((*ptr>0 && *ptr<32)||(*ptr=='\"')||(*ptr=='\\'))?1:0;

...

if (!str)
...
```