### PR TITLE
Using values in powers of two for cJSON_* constants

### DIFF
--- a/cJSON.h
+++ b/cJSON.h
@@ -29,14 +29,14 @@ extern "C"
 #endif
 
 /* cJSON Types: */
-#define cJSON_False 0
-#define cJSON_True 1
-#define cJSON_NULL 2
-#define cJSON_Number 3
-#define cJSON_String 4
-#define cJSON_Array 5
-#define cJSON_Object 6
-	
+#define cJSON_False  (1 << 0)
+#define cJSON_True   (1 << 1)
+#define cJSON_NULL   (1 << 2)
+#define cJSON_Number (1 << 3)
+#define cJSON_String (1 << 4)
+#define cJSON_Array  (1 << 5)
+#define cJSON_Object (1 << 6)
+
 #define cJSON_IsReference 256
 #define cJSON_StringIsConst 512
 


### PR DESCRIPTION
we can thus use bitops to identify if a cJSON object is of type Array, NULL etc in one operation