### PR TITLE
fixed segmentation fault for non-json input / provided test case

### DIFF
--- a/cJSON.c
+++ b/cJSON.c
@@ -660,8 +660,8 @@ static char *print_object(cJSON *item,int depth,int fmt,printbuffer *p)
 
 /* Get Array size/item / object item. */
 int    cJSON_GetArraySize(cJSON *array)							{cJSON *c=array->child;int i=0;while(c)i++,c=c->next;return i;}
-cJSON *cJSON_GetArrayItem(cJSON *array,int item)				{cJSON *c=array->child;  while (c && item>0) item--,c=c->next; return c;}
-cJSON *cJSON_GetObjectItem(cJSON *object,const char *string)	{cJSON *c=object->child; while (c && cJSON_strcasecmp(c->string,string)) c=c->next; return c;}
+cJSON *cJSON_GetArrayItem(cJSON *array,int item)				{cJSON *c; if (array == NULL) return NULL; c=array->child;  while (c && item>0) item--,c=c->next; return c;}
+cJSON *cJSON_GetObjectItem(cJSON *object,const char *string)	{cJSON *c; if (object == NULL) return NULL; c=object->child; while (c && cJSON_strcasecmp(c->string,string)) c=c->next; return c;}
 int cJSON_HasObjectItem(cJSON *object,const char *string)	{
 	cJSON *c=object->child;
 	while (c )

--- a/test.c
+++ b/test.c
@@ -144,12 +144,30 @@ int main (int argc, const char * argv[]) {
 	char text4[]="{\n		\"Image\": {\n			\"Width\":  800,\n			\"Height\": 600,\n			\"Title\":  \"View from 15th Floor\",\n			\"Thumbnail\": {\n				\"Url\":    \"http:/*www.example.com/image/481989943\",\n				\"Height\": 125,\n				\"Width\":  \"100\"\n			},\n			\"IDs\": [116, 943, 234, 38793]\n		}\n	}";
 	char text5[]="[\n	 {\n	 \"precision\": \"zip\",\n	 \"Latitude\":  37.7668,\n	 \"Longitude\": -122.3959,\n	 \"Address\":   \"\",\n	 \"City\":      \"SAN FRANCISCO\",\n	 \"State\":     \"CA\",\n	 \"Zip\":       \"94107\",\n	 \"Country\":   \"US\"\n	 },\n	 {\n	 \"precision\": \"zip\",\n	 \"Latitude\":  37.371991,\n	 \"Longitude\": -122.026020,\n	 \"Address\":   \"\",\n	 \"City\":      \"SUNNYVALE\",\n	 \"State\":     \"CA\",\n	 \"Zip\":       \"94085\",\n	 \"Country\":   \"US\"\n	 }\n	 ]";
 
+    char text6[] = "<!DOCTYPE html>"
+        "<html>\n"
+        "<head>\n"
+        "  <meta name=\"viewport\" content=\"width=device-width, initial-scale=1\">\n"
+        "  <style type=\"text/css\">\n"
+        "    html, body, iframe { margin: 0; padding: 0; height: 100%; }\n"
+        "    iframe { display: block; width: 100%; border: none; }\n"
+        "  </style>\n"
+        "<title>Application Error</title>\n"
+        "</head>\n"
+        "<body>\n"
+        "  <iframe src="//s3.amazonaws.com/heroku_pages/error.html">\n"
+        "    <p>Application Error</p>\n"
+        "  </iframe>\n"
+        "</body>\n"
+        "</html>\n";
+
 	/* Process each json textblock by parsing, then rebuilding: */
 	doit(text1);
 	doit(text2);	
 	doit(text3);
 	doit(text4);
 	doit(text5);
+    doit(text6);
 
 	/* Parse standard testfiles: */
 /*	dofile("../../tests/test1"); */
@@ -157,6 +175,7 @@ int main (int argc, const char * argv[]) {
 /*	dofile("../../tests/test3"); */
 /*	dofile("../../tests/test4"); */
 /*	dofile("../../tests/test5"); */
+/*	dofile("../../tests/test6"); */
 
 	/* Now some samplecode for building objects concisely: */
 	create_objects();

--- a/tests/test6
+++ b/tests/test6
@@ -1,0 +1,16 @@
+<!DOCTYPE html>
+    <html>
+    <head>
+      <meta name="viewport" content="width=device-width, initial-scale=1">
+      <style type="text/css">
+        html, body, iframe { margin: 0; padding: 0; height: 100%; }
+        iframe { display: block; width: 100%; border: none; }
+      </style>
+    <title>Application Error</title>
+    </head>
+    <body>
+      <iframe src="//s3.amazonaws.com/heroku_pages/error.html">
+        <p>Application Error</p>
+      </iframe>
+    </body>
+    </html>


### PR DESCRIPTION
Hey there,

I discovered a segmentation fault when the lib is fed with HTML including embedded CSS. I did not dive in too deep but rather just fixed the place where the seg fault occurs. Also added a test case for this. I noticed the lack of invalid JSON tests as well as non-JSON as test cases. This should be something to look into, shouldn't it?

The test case is actually just the heroku error page when the instance crashes, so this is somewhat likely to occur in the wild.